### PR TITLE
LICENSE

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,10 @@
         "type": "git",
         "url": "https://github.com/themesberg/volt-bootstrap-5-dashboard"
     },
-    "license": "https://github.com/themesberg/volt-bootstrap-5-dashboard/blob/master/LICENSE.md",
+    "license": {
+        "type" : "MIT",
+        "url" : "https://github.com/themesberg/volt-bootstrap-5-dashboard/blob/master/LICENSE.md"
+    },
     "dependencies": {
         "@popperjs/core": "^2.9.2",
         "bootstrap": "^5.0.2",


### PR DESCRIPTION
npm WARN @themesberg/volt-bootstrap-5-dashboard@1.4.1 license should be a valid SPDX license expression